### PR TITLE
Minor Changes to Decrypt API Key within LA Guide

### DIFF
--- a/decrypt-api-key-in-action/README.md
+++ b/decrypt-api-key-in-action/README.md
@@ -4,10 +4,11 @@ This example shows how you can encrypt an api key on the client with specific de
 
 Before running, there are two variables to configure within `index.ts`:
 
-**Note: ts-node-esm requires NodeJS version 19**
+**Note: ts-node-esm requires NodeJS version 20**
+
 ```js
 const url = `<your http endpoint for api-key usage>`;
-const key = '<your api key>';
+const key = "<your api key>";
 ```
 
 ## Restricting your api key to only be used by a single Lit Action
@@ -16,17 +17,17 @@ Within the code you will see the below ACC condition:
 
 ```js
 const accessControlConditions = [
-    {
-        contractAddress: '',
-        standardContractType: '',
-        chain,
-        method: 'eth_getBalance',
-        parameters: [':userAddress', 'latest'],
-        returnValueTest: {
-            comparator: '>=',
-            value: '0',
-        },
+  {
+    contractAddress: "",
+    standardContractType: "",
+    chain,
+    method: "eth_getBalance",
+    parameters: [":userAddress", "latest"],
+    returnValueTest: {
+      comparator: ">=",
+      value: "0",
     },
+  },
 ];
 ```
 
@@ -34,17 +35,18 @@ You can change the above to the below to use the parameter: `:currentActionId` w
 
 ```js
 const accessControlConditions = [
-    {
-        contractAddress: '',
-        standardContractType: '',
-        chain,
-        method: 'eth_getBalance',
-        parameters: [':currentActionId', 'latest'],
-        returnValueTest: {
-            comparator: '==',
-            value: '<your ipfs id>',
-        },
+  {
+    contractAddress: "",
+    standardContractType: "",
+    chain,
+    method: "eth_getBalance",
+    parameters: [":currentActionId", "latest"],
+    returnValueTest: {
+      comparator: "==",
+      value: "<your ipfs id>",
     },
+  },
 ];
 ```
+
 For easy upload of your Lit Action source code you can use the explorer [here](https://explorer.litprotocol.com/create-action)

--- a/decrypt-api-key-in-action/package.json
+++ b/decrypt-api-key-in-action/package.json
@@ -16,6 +16,6 @@
     "siwe": "^2.0.0"
   },
   "scripts": {
-    "start": "ts-node-esm src/index.ts"
+    "start": "node --loader ts-node/esm src/index.ts"
   }
 }


### PR DESCRIPTION
- I've updated the required NodeJS version to `v20` from `v19`
    When attempting to run `yarn` with `v19`, I get the following error:
  ```ts
  yarn install v1.22.22
  warning ../../../package.json: No license field
  [1/4] 🔍  Resolving packages...
  [2/4] 🚚  Fetching packages...
  error node-addon-api@7.1.0: The engine "node" is incompatible with this module. Expected version "^16 || ^18 || >= 20". Got "19.9.0"
  error Found incompatible module.
  info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
  ```
    Upgrading to `v20` fixes the error
- I updated the `package.json` `start` script command because the existing command was giving me the error:
  ```ts
  yarn run v1.22.22
  warning ../../../package.json: No license field
  $ ts-node-esm src/index.ts
  TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/whyit/tmp/developer-guides-code/decrypt-api-key-in-action/src/index.ts
      at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:160:9)
      at defaultGetFormat (node:internal/modules/esm/get_format:203:36)
      at defaultLoad (node:internal/modules/esm/load:143:22)
      at async nextLoad (node:internal/modules/esm/hooks:865:22)
      at async nextLoad (node:internal/modules/esm/hooks:865:22)
      at async Hooks.load (node:internal/modules/esm/hooks:448:20)
      at async MessagePort.handleMessage (node:internal/modules/esm/worker:196:18) {
    code: 'ERR_UNKNOWN_FILE_EXTENSION'
  }
  error Command failed with exit code 1.
  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
  ```