### PR TITLE
Fixed getLitActionSessionSigs + SessionSigs Versions to 6.4.0

### DIFF
--- a/session-signatures/getLitActionSessionSigs/package.json
+++ b/session-signatures/getLitActionSessionSigs/package.json
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^0.44.1",
-    "@lit-protocol/auth-helpers": "^6.3.0",
-    "@lit-protocol/constants": "^6.3.0",
-    "@lit-protocol/lit-auth-client": "^6.3.0",
-    "@lit-protocol/lit-node-client": "^6.3.0",
+    "@lit-protocol/auth-helpers": "^6.4.0",
+    "@lit-protocol/constants": "^6.4.0",
+    "@lit-protocol/lit-auth-client": "^6.4.0",
+    "@lit-protocol/lit-node-client": "^6.4.0",
     "ethers": "v5",
     "node-localstorage": "^3.0.5"
   },

--- a/session-signatures/getLitActionSessionSigs/src/index.ts
+++ b/session-signatures/getLitActionSessionSigs/src/index.ts
@@ -1,5 +1,5 @@
 import { LitNodeClient } from "@lit-protocol/lit-node-client";
-import { LitNetwork, LIT_RPC } from "@lit-protocol/constants";
+import { LitNetwork, LIT_RPC, AuthMethodScope } from "@lit-protocol/constants";
 import { LitContracts } from "@lit-protocol/contracts-sdk";
 import {
   LitAbility,
@@ -48,9 +48,16 @@ export const getSessionSigsLitAction = async () => {
       `✅ Minted new PKP with public key: ${pkp.publicKey} and ETH address: ${pkp.ethAddress}`
     );
 
-    const litActionCode = `(async () => {
-      Lit.Actions.setResponse({ response: "true" });
-    })();`;
+    console.log("🔄 Adding example permitted Lit Action to the PKP");
+    await litContracts.addPermittedAction({
+      ipfsId: "QmTaYbqnGwrmseoDQdTNoU9FNzaiaTpKApgMFWqbsWs4Cr",
+      pkpTokenId: pkp.tokenId,
+      authMethodScopes: [AuthMethodScope.SignAnything],
+    });
+    console.log("✅ Example Lit Action permissions added to the PKP");
+
+    // Not necessarily needed here, but this is our Lit Action code on the IPFS
+    const litActionCode = `(async () => {LitActions.setResponse({ response: makeItTrue });})();`;
 
     console.log("🔄 Getting Session Sigs...");
     const sessionSignatures = await litNodeClient.getLitActionSessionSigs({
@@ -66,8 +73,12 @@ export const getSessionSigsLitAction = async () => {
           ability: LitAbility.LitActionExecution,
         },
       ],
-      litActionCode: Buffer.from(litActionCode).toString('base64'),
-      jsParams: {},
+      // With this setup you could use either the litActionIpfsId or the litActionCode property
+      litActionIpfsId: "QmTaYbqnGwrmseoDQdTNoU9FNzaiaTpKApgMFWqbsWs4Cr",
+      //litActionCode: Buffer.from(litActionCode).toString('base64'),
+      jsParams: {
+        makeItTrue: "true",
+      },
     });
     console.log("✅ Got Session Sigs");
 

--- a/session-signatures/getPkpSessionSigs/package.json
+++ b/session-signatures/getPkpSessionSigs/package.json
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^0.44.1",
-    "@lit-protocol/auth-helpers": "^6.3.0",
-    "@lit-protocol/constants": "^6.3.0",
-    "@lit-protocol/lit-auth-client": "^6.3.0",
-    "@lit-protocol/lit-node-client": "^6.3.0",
+    "@lit-protocol/auth-helpers": "^6.4.0",
+    "@lit-protocol/constants": "^6.4.0",
+    "@lit-protocol/lit-auth-client": "^6.4.0",
+    "@lit-protocol/lit-node-client": "^6.4.0",
     "ethers": "v5",
     "node-localstorage": "^3.0.5"
   },

--- a/session-signatures/getSessionSigs/package.json
+++ b/session-signatures/getSessionSigs/package.json
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^0.44.1",
-    "@lit-protocol/auth-helpers": "^6.3.0",
-    "@lit-protocol/constants": "^6.3.0",
-    "@lit-protocol/lit-node-client": "^6.3.0",
+    "@lit-protocol/auth-helpers": "^6.4.0",
+    "@lit-protocol/constants": "^6.4.0",
+    "@lit-protocol/lit-node-client": "^6.4.0",
     "ethers": "v5",
     "node-localstorage": "^3.0.5"
   },


### PR DESCRIPTION
As title says, fixing the issue encountered by the team last week. 

We have to add the permitted action to the PKP before we can get the session signatures using `getLitActionSessionSigs`.

Versions have also been updated to `6.4.0`