### PR TITLE
Browser ENV fix

### DIFF
--- a/conditional-signing/browser/src/utils.ts
+++ b/conditional-signing/browser/src/utils.ts
@@ -1,5 +1,5 @@
 export const getEnv = (name: string): string => {
-  const env = process.env[name];
+  const env = import.meta.env[name];
   if (env === undefined || env === "")
     throw new Error(
       `${name} ENV is not defined, please define it in the .env file`


### PR DESCRIPTION
Quick ENV fix, using `import.meta.env` instead of `process.env`